### PR TITLE
V5 rewrite gather loop

### DIFF
--- a/dual_net.py
+++ b/dual_net.py
@@ -88,7 +88,7 @@ class DualNetworkTrainer():
             tf.train.Saver().save(sess, self.save_file)
 
     def train(self, tf_records, init_from=None, num_steps=None,
-              logging_freq=100, verbosity=1):
+              logging_freq=1000, verbosity=1):
         """
         Train a model on the set of records given by tf_records.
         tf_records will *not* be filtered.
@@ -351,7 +351,7 @@ def train_ops(input_tensors, output_tensors, **hparams):
     policy_output = output_tensors['policy_output']
     policy_entropy = -tf.reduce_mean(tf.reduce_sum(
         policy_output * tf.log(policy_output), axis=1))
-    boundaries = list(map(int, [1e6, 2 * 1e6]))
+    boundaries = list(map(int, [18 * 1e6, 36 * 1e6]))
     values = [1e-2, 1e-3, 1e-4]
     learning_rate = tf.train.piecewise_constant(
         global_step, boundaries, values)

--- a/dual_net.py
+++ b/dual_net.py
@@ -93,6 +93,7 @@ class DualNetworkTrainer():
         Train a model on the set of records given by tf_records.
         tf_records will *not* be filtered.
         """
+        tf.logging.set_verbosity(tf.logging.WARN)  # Hide startup spam
         logdir = os.path.join(
             self.logdir, 'train') if self.logdir is not None else None
 

--- a/dual_net.py
+++ b/dual_net.py
@@ -89,6 +89,10 @@ class DualNetworkTrainer():
 
     def train(self, tf_records, init_from=None, num_steps=None,
               logging_freq=100, verbosity=1):
+        """
+        Train a model on the set of records given by tf_records.
+        tf_records will *not* be filtered.
+        """
         logdir = os.path.join(
             self.logdir, 'train') if self.logdir is not None else None
 
@@ -98,7 +102,7 @@ class DualNetworkTrainer():
             num_steps = EXAMPLES_PER_GENERATION // TRAIN_BATCH_SIZE
         with self.sess.graph.as_default():
             input_tensors = preprocessing.get_input_tensors(
-                TRAIN_BATCH_SIZE, tf_records)
+                TRAIN_BATCH_SIZE, tf_records, filter_amount=1.0)
             output_tensors = dual_net(input_tensors, TRAIN_BATCH_SIZE,
                                       train_mode=True, **self.hparams)
             train_tensors = train_ops(

--- a/dual_net.py
+++ b/dual_net.py
@@ -351,7 +351,7 @@ def train_ops(input_tensors, output_tensors, **hparams):
     policy_output = output_tensors['policy_output']
     policy_entropy = -tf.reduce_mean(tf.reduce_sum(
         policy_output * tf.log(policy_output), axis=1))
-    boundaries = list(map(int, [18 * 1e6, 36 * 1e6]))
+    boundaries = list(map(int, [10 * 1e6, 20 * 1e6]))
     values = [1e-2, 1e-3, 1e-4]
     learning_rate = tf.train.piecewise_constant(
         global_step, boundaries, values)

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -124,7 +124,7 @@ def _rsync_dir(source_dir, dest_dir):
 
 
 def loop(bufsize=dual_net.EXAMPLES_PER_GENERATION,
-         write_dir=rl_loop.TRAINING_CHUNK_DIR,
+         write_dir=rl_loop.GOLDEN_CHUNK_DIR,
          model_window=100,
          threads=8,
          skip_first_rsync=False):

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -133,6 +133,8 @@ def fill_and_wait(bufsize=dual_net.EXAMPLES_PER_GENERATION,
     while tf.gfile.Exists(chunk_to_make):
         print("Next chunk ({}) already exists.  Sleeping.".format(chunk_to_make))
         time.sleep(5*60)
+        models = rl_loop.get_models()[-model_window:]
+    print("Making chunk:", chunk_to_make)
     if not skip_first_rsync:
         with timer("Rsync"):
             smart_rsync(models[-1][0] - 6)

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -168,7 +168,8 @@ def make_chunk_for(output_dir=LOCAL_DIR,
         files += tf.gfile.Glob(os.path.join(local_model_dir, '*.zz'))
         cur_model -= 1
 
-    buf.parallel_fill(files, samples_per_game)
+    buf.parallel_fill(files, threads=threads,
+                      samples_per_game=samples_per_game)
     print(buf)
     buf.flush(os.path.join(output_dir, str(model_num) + '.tfrecord.zz'))
 

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -132,6 +132,8 @@ def _ensure_dir_exists(directory):
     os.makedirs(directory, exist_ok=True)
 
 
+parser = argparse.ArgumentParser()
+argh.add_commands(parser, [loop, smart_rsync])
+
 if __name__ == "__main__":
-    argh.dispatch(loop)
-    pass
+    argh.dispatch(parser)

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -88,7 +88,6 @@ class ExampleBuffer():
             self.examples.extend(choices)
 
     def flush(self, path):
-        print(self)
         preprocessing.write_tf_examples(path, [ex[1] for ex in self.examples])
 
     @property
@@ -159,7 +158,7 @@ def make_chunk_for(output_dir=LOCAL_DIR,
     buf = ExampleBuffer(positions)
     cur_model = model_num - 1
     files = []
-    while len(files) < (positions * samples_per_game) and cur_model >= 0:
+    while (len(files) * samples_per_game) < positions and cur_model >= 0:
         local_model_dir = os.path.join(LOCAL_DIR, models[cur_model])
         if not tf.gfile.Exists(local_model_dir):
             print("Rsyncing", models[cur_model])
@@ -167,6 +166,8 @@ def make_chunk_for(output_dir=LOCAL_DIR,
                 game_dir, models[cur_model]), local_model_dir)
         files += tf.gfile.Glob(os.path.join(local_model_dir, '*.zz'))
         cur_model -= 1
+
+    print("Filling from {} files".format(len(files)))
 
     buf.parallel_fill(files, threads=threads,
                       samples_per_game=samples_per_game)

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -1,33 +1,40 @@
-import tensorflow as tf
+from tensorflow import gfile
 import os
 import random
 from tqdm import tqdm
 import multiprocessing as mp
 import functools
+import itertools
+import rl_loop
+import dual_net
+import subprocess
+from utils import timer
+import time
 
 
 # 1 for ZLIB!  Make this match preprocessing.
 READ_OPTS = tf.python_io.TFRecordOptions(1)
 
+LOCAL_DIR = "data/"
 
-def read_tfrecord_to_example_list(filename):
+
+def pick_examples_from_tfrecord(filename, samples_per_game=4):
     protos = [p for p in
               tf.python_io.tf_record_iterator(filename, READ_OPTS)]
+    choices = random.sample(protos, samples_per_game)
 
     def make_example(protostring):
         e = tf.train.Example()
         e.ParseFromString(protostring)
         return e
-    examples = list(map(make_example, protos))
+    examples = list(map(make_example, choices))
     return examples
 
 
 def choose(g, samples_per_game=4):
-    examples = read_tfrecord_to_example_list(g)
+    examples = pick_examples_from_tfrecord(g, samples_per_game)
     t = file_timestamp(g)
-    choices = [(t, s)
-               for s in random.sample(examples, samples_per_game)]
-    return choices
+    return [(t, ex) for ex in examples]
 
 
 def file_timestamp(filename):
@@ -47,9 +54,8 @@ class ExampleBuffer():
         f = functools.partial(choose, samples_per_game=samples_per_game)
 
         with mp.Pool(threads) as p:
-            r = list(tqdm(p.imap(f, games), total=len(games)))
-
-        return r
+             r = tqdm(p.imap(f, games), total=len(games))
+             self.examples = list(itertools.chain(*r))
 
     def update(self, new_games, samples_per_game=4):
         """
@@ -57,10 +63,71 @@ class ExampleBuffer():
         """
         new_games.sort(key=lambda f: os.path.basename(f))
         for game in tqdm(new_games):
-            examples = read_tfrecord_to_example_list(game)
             t = file_timestamp(game)
-            choices = [(t, s)
-                       for s in random.sample(examples, samples_per_game)]
+            if t <= self.examples[-1][0]:
+                continue
+            print("New game:", os.path.basename(game))
+            choices = [(t, ex) for ex in pick_examples_from_tfrecord(
+                game, samples_per_game)]
             if len(self.examples) > self.max_size:
                 self.examples = self.examples[samples_per_game:]
             self.examples.extend(choices)
+
+    def flush(self, path):
+        preprocessing.write_tf_examples(path, self.examples)
+
+
+def files_for_model(model):
+    return gfile.Glob(os.path.join(LOCAL_DIR, model[1], '*.zz'))
+
+
+def smart_rsync(from_model_num=0, source_dir=rl_loop.SELFPLAY_DIR, dest_dir=LOCAL_DIR):
+    from_model_num = 0 if from_model_num < 0 else from_model_num
+    models = [m for m in rl_loop.get_models() if m[0] >= from_model_num]
+    for m in models:
+        _ensure_dir_exists(os.path.join(LOCAL_DIR, m[1]))
+        subprocess.call(['gsutil', '-m', 'rsync',
+                         os.path.join(source_dir, m[1]), os.path.join(dest_dir, m[1])],
+                        stderr=open('.rsync_log', 'ab'))
+
+
+def loop(bufsize=dual_net.EXAMPLES_PER_GENERATION,
+         write_dir=rl_loop.TRAINING_CHUNK_DIR,
+         model_window=100,
+         threads=8,
+         skip_first_rsync=False):
+    buf = ExampleBuffer(bufsize)
+
+    while True:
+        models = rl_loop.get_models()[-model_window:]
+        if not skip_first_rsync:
+            with timer("Rsync"):
+                smart_rsync(models[-1][0] - 6)
+        files = list(tqdm(map(files_for_model, models), total=len(models)))
+        buf.parallel_fill(list(itertools.chain(*files)))
+
+        print("Filled buffer, watching for new games")
+
+        while rl_loop.get_latest_model()[0] == models[-1][0]:
+            with timer("Rsync"):
+                smart_rsync(models[-1][0] - 2)
+            new_files = list(
+                tqdm(map(files_for_model, models[-2:]), total=len(models)))
+            buf.update(list(itertools.chain(*new_files)))
+            print("Sleeping")
+            time.sleep(5*60)
+        latest = rl_loop.get_latest_model()
+
+        print("New model!", latest[1], "!=", models[-1][1])
+        buf.flush(os.path.join(write_dir, latest[0]+1))
+
+
+def _ensure_dir_exists(directory):
+    if directory.startswith('gs://'):
+        return
+    os.makedirs(directory, exist_ok=True)
+
+
+if __name__ == "__main__":
+    argh.dispatch(loop)
+    pass

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -145,11 +145,13 @@ def loop(bufsize=dual_net.EXAMPLES_PER_GENERATION,
             new_files = list(
                 tqdm(map(files_for_model, models[-2:]), total=len(models)))
             buf.update(list(itertools.chain(*new_files)))
-            print(self)
         latest = rl_loop.get_latest_model()
 
         print("New model!", latest[1], "!=", models[-1][1])
+        print(buf)
         buf.flush(os.path.join(write_dir, str(latest[0]+1) + '.tfrecord.zz'))
+        del buf
+        buf = ExampleBuffer(bufsize)
 
 
 def make_chunk_for(output_dir=LOCAL_DIR,

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -1,0 +1,40 @@
+import tensorflow as tf
+import os
+import random
+from tqdm import tqdm
+
+
+# 1 for ZLIB!  Make this match preprocessing.
+READ_OPTS = tf.python_io.TFRecordOptions(1) 
+
+def read_tfrecord_to_example_list(filename):
+    protos = [p for p in 
+            tf.python_io.tf_record_iterator(filename, READ_OPTS)]
+    def make_example(protostring):
+        e = tf.train.Example()
+        e.ParseFromString(protostring)
+        return e
+    examples = list(map(make_example, protos))
+    return examples
+
+def file_timestamp(filename):
+    return int(os.path.basename(filename).split('-')[0])
+
+
+class ExampleBuffer():
+    def __init__(self, max_size=2000000):
+        self.examples = []
+        self.max_size = max_size
+
+    def update(self, new_games, samples_per_game=4):
+        """
+        new_games is list of .tfrecord.zz files of new games
+        """
+        for game in tqdm(sorted(new_games, key=lambda f: os.path.basename(f))): 
+            examples = read_tfrecord_to_example_list(game)
+            t = file_timestamp(game)
+            choices = [(t, s) for s in random.sample(examples, samples_per_game)]
+            if len(self.examples) > self.max_size:
+                self.examples = self.examples[samples_per_game:]
+            self.examples.extend(choices)
+

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -91,6 +91,7 @@ class ExampleBuffer():
         with timer("Writing examples to " + path):
             preprocessing.write_tf_examples(
                 path, [ex[1] for ex in self.examples])
+        del self.examples
         self.examples = []
 
     @property

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -127,8 +127,11 @@ def fill_and_wait(bufsize=dual_net.EXAMPLES_PER_GENERATION,
                   skip_first_rsync=False):
     buf = ExampleBuffer(bufsize)
     models = rl_loop.get_models()[-model_window:]
-    while tf.gfile.Exists(os.path.join(rl_loop.GOLDEN_CHUNK_DIR, str(models[-1][0] + 1) + '.tfrecord.zz')):
-        print("Next chunk already exists.  Sleeping.")
+    # Last model is N.  N+1 is training.  We should gather games for N+2.
+    chunk_to_make = os.path.join(rl_loop.GOLDEN_CHUNK_DIR, str(
+        models[-1][0] + 2) + '.tfrecord.zz')
+    while tf.gfile.Exists(chunk_to_make):
+        print("Next chunk ({}) already exists.  Sleeping.".format(chunk_to_make))
         time.sleep(5*60)
     if not skip_first_rsync:
         with timer("Rsync"):

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -91,6 +91,7 @@ class ExampleBuffer():
         with timer("Writing examples to " + path):
             preprocessing.write_tf_examples(
                 path, [ex[1] for ex in self.examples])
+        self.examples = []
 
     @property
     def count(self):

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -2,20 +2,33 @@ import tensorflow as tf
 import os
 import random
 from tqdm import tqdm
+import multiprocessing as mp
+import functools
 
 
 # 1 for ZLIB!  Make this match preprocessing.
-READ_OPTS = tf.python_io.TFRecordOptions(1) 
+READ_OPTS = tf.python_io.TFRecordOptions(1)
+
 
 def read_tfrecord_to_example_list(filename):
-    protos = [p for p in 
-            tf.python_io.tf_record_iterator(filename, READ_OPTS)]
+    protos = [p for p in
+              tf.python_io.tf_record_iterator(filename, READ_OPTS)]
+
     def make_example(protostring):
         e = tf.train.Example()
         e.ParseFromString(protostring)
         return e
     examples = list(map(make_example, protos))
     return examples
+
+
+def choose(g, samples_per_game=4):
+    examples = read_tfrecord_to_example_list(g)
+    t = file_timestamp(g)
+    choices = [(t, s)
+               for s in random.sample(examples, samples_per_game)]
+    return choices
+
 
 def file_timestamp(filename):
     return int(os.path.basename(filename).split('-')[0])
@@ -26,15 +39,28 @@ class ExampleBuffer():
         self.examples = []
         self.max_size = max_size
 
+    def parallel_fill(self, games, threads=8, samples_per_game=4):
+        games.sort(key=lambda f: os.path.basename(f))
+        if len(games) * samples_per_game > self.max_size:
+            games = games[-1 * self.max_size // samples_per_game:]
+
+        f = functools.partial(choose, samples_per_game=samples_per_game)
+
+        with mp.Pool(threads) as p:
+            r = list(tqdm(p.imap(f, games), total=len(games)))
+
+        return r
+
     def update(self, new_games, samples_per_game=4):
         """
         new_games is list of .tfrecord.zz files of new games
         """
-        for game in tqdm(sorted(new_games, key=lambda f: os.path.basename(f))): 
+        new_games.sort(key=lambda f: os.path.basename(f))
+        for game in tqdm(new_games):
             examples = read_tfrecord_to_example_list(game)
             t = file_timestamp(game)
-            choices = [(t, s) for s in random.sample(examples, samples_per_game)]
+            choices = [(t, s)
+                       for s in random.sample(examples, samples_per_game)]
             if len(self.examples) > self.max_size:
                 self.examples = self.examples[samples_per_game:]
             self.examples.extend(choices)
-

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -25,6 +25,8 @@ LOCAL_DIR = "data/"
 def pick_examples_from_tfrecord(filename, samples_per_game=4):
     protos = [p for p in
               tf.python_io.tf_record_iterator(filename, READ_OPTS)]
+    if len(protos) < 20:
+        return []
     choices = random.sample(protos, samples_per_game)
 
     def make_example(protostring):

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -127,6 +127,9 @@ def fill_and_wait(bufsize=dual_net.EXAMPLES_PER_GENERATION,
                   skip_first_rsync=False):
     buf = ExampleBuffer(bufsize)
     models = rl_loop.get_models()[-model_window:]
+    while tf.gfile.Exists(os.path.join(rl_loop.GOLDEN_CHUNK_DIR, str(models[-1][0] + 1) + '.tfrecord.zz')):
+        print("Next chunk already exists.  Sleeping.")
+        time.sleep(5*60)
     if not skip_first_rsync:
         with timer("Rsync"):
             smart_rsync(models[-1][0] - 6)

--- a/example_buffer.py
+++ b/example_buffer.py
@@ -119,7 +119,7 @@ def loop(bufsize=dual_net.EXAMPLES_PER_GENERATION,
         latest = rl_loop.get_latest_model()
 
         print("New model!", latest[1], "!=", models[-1][1])
-        buf.flush(os.path.join(write_dir, latest[0]+1))
+        buf.flush(os.path.join(write_dir, str(latest[0]+1)))
 
 
 def _ensure_dir_exists(directory):

--- a/main.py
+++ b/main.py
@@ -89,7 +89,8 @@ def train_dir(chunk_dir, save_file, load_file=None,
 
 
 def train(chunks, save_file, load_file=None,
-          logdir=None, num_steps=0, verbosity=1):
+          logdir=None, num_steps=None, verbosity=1):
+    """ If num_steps is None, defaults to params in dual_net """
     print("Training on:", chunks[0], "to", chunks[-1])
     n = dual_net.DualNetworkTrainer(save_file, logdir=logdir)
     with timer("Training"):

--- a/main.py
+++ b/main.py
@@ -190,6 +190,8 @@ def gather(
     print("Found %d models" % len(models))
     for model_name, record_files in sorted(model_gamedata.items()):
         print("    %s: %s files" % (model_name, len(record_files)))
+    print(" >> {} total games".format(
+        sum([len(f) for f in model_gamedata.values()])))
 
     meta_file = os.path.join(output_directory, 'meta.txt')
     try:

--- a/main.py
+++ b/main.py
@@ -80,16 +80,20 @@ def bootstrap(save_file):
     dual_net.DualNetworkTrainer(save_file).bootstrap()
 
 
-def train(chunk_dir, save_file, load_file=None,
-          logdir=None, num_steps=0, verbosity=1):
+def train_dir(chunk_dir, save_file, load_file=None,
+              logdir=None, num_steps=0, verbosity=1):
     tf_records = sorted(gfile.Glob(os.path.join(chunk_dir, '*.tfrecord.zz')))
     tf_records = tf_records[-1 * (WINDOW_SIZE // EXAMPLES_PER_RECORD):]
 
-    print("Training from:", tf_records[0], "to", tf_records[-1])
+    train(tf_records, save_file, load_file, logdir, num_steps, verbosity)
 
+
+def train(chunks, save_file, load_file=None,
+          logdir=None, num_steps=0, verbosity=1):
+    print("Training on:", chunks[0], "to", chunks[-1])
     n = dual_net.DualNetworkTrainer(save_file, logdir=logdir)
     with timer("Training"):
-        n.train(tf_records, init_from=load_file,
+        n.train(chunks, init_from=load_file,
                 num_steps=num_steps, verbosity=verbosity)
 
 

--- a/main.py
+++ b/main.py
@@ -80,8 +80,8 @@ def bootstrap(save_file):
     dual_net.DualNetworkTrainer(save_file).bootstrap()
 
 
-def train(chunk_dir, save_file, load_file=None, generation_num=0,
-          logdir=None, num_steps=None, verbosity=1):
+def train(chunk_dir, save_file, load_file=None,
+          logdir=None, num_steps=0, verbosity=1):
     tf_records = sorted(gfile.Glob(os.path.join(chunk_dir, '*.tfrecord.zz')))
     tf_records = tf_records[-1 * (WINDOW_SIZE // EXAMPLES_PER_RECORD):]
 

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -22,6 +22,7 @@ import main
 import shipname
 import sys
 import time
+import tempfile
 from utils import timer
 from tensorflow import gfile
 
@@ -153,20 +154,20 @@ def train(logdir=None, load_dir=MODELS_DIR, save_dir=MODELS_DIR):
     new_model_name = shipname.generate(model_num + 1)
     print("New model will be {}".format(new_model_name))
     training_file = os.path.join(
-        TRAINING_CHUNK_DIR, str(model_num + 1), '.tfrecord.zz')
+        GOLDEN_CHUNK_DIR, str(model_num + 1) + '.tfrecord.zz')
     while not gfile.Exists(training_file):
         print("Waiting for", training_file)
         time.sleep(1*60)
 
     with tempfile.TemporaryDirectory() as base_dir:
         local_copy = os.path.join(base_dir, os.path.basename(training_file))
-        tf.gfile.Copy(training_file, local_copy)
+        gfile.Copy(training_file, local_copy)
 
         load_file = os.path.join(load_dir, model_name)
         save_file = os.path.join(save_dir, new_model_name)
         try:
             main.train([local_copy], save_file=save_file, load_file=load_file,
-                       generation_num=model_num, logdir=logdir)
+                       logdir=logdir)
         except:
             logging.exception("Train error")
 

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -151,10 +151,11 @@ def train(logdir=None, load_dir=MODELS_DIR, save_dir=MODELS_DIR):
         sys.exit(1)
 
     print("Training on gathered game data, initializing from {}".format(model_name))
-    new_model_name = shipname.generate(model_num + 1)
+    new_model_num = model_num + 1
+    new_model_name = shipname.generate(new_model_num)
     print("New model will be {}".format(new_model_name))
     training_file = os.path.join(
-        GOLDEN_CHUNK_DIR, str(model_num + 1) + '.tfrecord.zz')
+        GOLDEN_CHUNK_DIR, str(new_model_num) + '.tfrecord.zz')
     while not gfile.Exists(training_file):
         print("Waiting for", training_file)
         time.sleep(1*60)

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -193,7 +193,7 @@ def validate(logdir=None, model_num=None):
 
     main.validate(*holdout_dirs,
                   load_file=os.path.join(MODELS_DIR, model_name),
-                  logdir=logdir)
+                  logdir=logdir, num_steps=2000)
 
 
 parser = argparse.ArgumentParser()

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -160,17 +160,13 @@ def train(logdir=None, load_dir=MODELS_DIR, save_dir=MODELS_DIR):
         time.sleep(1*60)
     print("Using Golden File:", training_file)
 
-    with tempfile.TemporaryDirectory() as base_dir:
-        local_copy = os.path.join(base_dir, os.path.basename(training_file))
-        gfile.Copy(training_file, local_copy)
-
-        load_file = os.path.join(load_dir, model_name)
-        save_file = os.path.join(save_dir, new_model_name)
-        try:
-            main.train([local_copy], save_file=save_file, load_file=load_file,
-                       logdir=logdir)
-        except:
-            logging.exception("Train error")
+    load_file = os.path.join(load_dir, model_name)
+    save_file = os.path.join(save_dir, new_model_name)
+    try:
+        main.train([training_file], save_file=save_file, load_file=load_file,
+                   logdir=logdir)
+    except:
+        logging.exception("Train error")
 
 
 def validate(logdir=None, model_num=None):

--- a/rl_loop.py
+++ b/rl_loop.py
@@ -41,7 +41,7 @@ GOLDEN_CHUNK_DIR = os.path.join(BASE_DIR, 'data', 'golden_chunks')
 MAX_GAMES_PER_GENERATION = 10000
 
 # How many games minimum, until the trainer will train
-MIN_GAMES_PER_GENERATION = 5000
+MIN_GAMES_PER_GENERATION = 500
 
 # What percent of games to holdout from training per generation
 HOLDOUT_PCT = 0.05
@@ -158,6 +158,7 @@ def train(logdir=None, load_dir=MODELS_DIR, save_dir=MODELS_DIR):
     while not gfile.Exists(training_file):
         print("Waiting for", training_file)
         time.sleep(1*60)
+    print("Using Golden File:", training_file)
 
     with tempfile.TemporaryDirectory() as base_dir:
         local_copy = os.path.join(base_dir, os.path.basename(training_file))

--- a/rl_runner.py
+++ b/rl_runner.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Run gather and train in a loop, as subprocesses.
+""" Run train and validate in a loop, as subprocesses.
 
 We run as subprocesses because it gives us some isolation.
-If the gather job dies more than three times, we quit entirely.
 """
 
 import subprocess
@@ -25,21 +24,9 @@ from utils import timer
 
 
 def loop(logdir=None):
-    """Run gather and train as subprocesses."""
-    gather_errors = 0
+    """Run train and validate as subprocesses."""
     while True:
         print("==================================")
-        with timer("Gather"):
-            gather = subprocess.call("python rl_loop.py gather".split())
-            if gather != 0:
-                print("Error in gather, retrying")
-                gather_errors += 1
-                if gather_errors == 3:
-                    print("Gathering died too many times!")
-                    sys.exit(1)
-                continue
-        gather_errors = 0
-
         with timer("Train"):
             train = subprocess.call(
                 ("python rl_loop.py train --logdir=%s" % logdir).split())

--- a/rl_runner.py
+++ b/rl_runner.py
@@ -41,8 +41,11 @@ def loop(logdir=None):
         gather_errors = 0
 
         with timer("Train"):
-            subprocess.call(
+            train = subprocess.call(
                 ("python rl_loop.py train --logdir=%s" % logdir).split())
+            if train != 0:
+                print("Skipping validation")
+                continue
 
         with timer("validate"):
             subprocess.call(


### PR DESCRIPTION
Rewrites the 'gather' functionality and replaces it with a rolling 'example buffer'.  This fills up with pre-filtered tfExamples while the new model is training, and then dumps it as a 'golden training file' as soon as the new model is complete.